### PR TITLE
Use 'env' in shebang for enhanced portability

### DIFF
--- a/iconizr.phps
+++ b/iconizr.phps
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 namespace Jkphl;


### PR DESCRIPTION
'#!/usr/bin/env php' is more portable than '#!/usr/bin/php' at the top of the script. Some people have unusual configurations for PHP (MAMP on the Mac, for example). It's a minor, but useful change.
