### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,6 @@
 {
   "name" : "jkphl/iconizr",
   "description" : "A PHP command line tool for converting SVG images to a set of CSS icons (SVG & PNG, single icons and / or CSS sprites) with support for image optimization and Sass output",
-  "repositories" : [ {
-    "type" : "composer",
-    "url" : "https://packagist.org/"
-  }, {
-    "type" : "vcs",
-    "url" : "https://github.com/jkphl/iconizr"
-  } ],
   "authors" : [ {
     "name" : "Joschi Kuphal",
     "email" : "joschi@kuphal.net",


### PR DESCRIPTION
cleanup default repositories. i don't think there's need to register these
- packagist is enabled by default in composer
- jkphl/iconizr is present in packagist: https://packagist.org/packages/jkphl/iconizr
